### PR TITLE
only need enum34 on python < 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     
     - CONDA_PY=27
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "oLMFt765yj90vcIjTXAa6AT4XNhWATCDITvnSLFJ/6+Kh8XoGK2URltNqEv6Lv3u36r9tjOGzgtVYU02pxz78bqOxnPUOgTAbIBp5wufvQt/nGDjXJJ5iglgNZBqrxXqC0yVu4vFoBKiKp8geONopMS2BptNIoUNUkJsjJ8P47Lgqi41LwC/izngtOor/3lMwi1EJyO2LOfikVVpbAOFLv5dpsX+mg5kw6EJMLmQon1WsQud4BexW40uFaFBtCB0z6/V7idzTJY4E1K6EwvF+CFOc/2QPHIQ0qokctmHRhLukGs/O26EdrBJXxmXRO7IDekPzgaF+z5GFTzQigrbAHZTkX2dbwV9OUpWiQjYWWo3fLD4Kdxorm7SSqjfNMVMTz5S3OhTv2/1ApOIDa7GFcJjusjpBPRUqep0k36Z6iJpdAp/bzLiIRmNRKHWDoZSnTq1h8vNAdtbAS5mCwpin8HOXbPlIaVJGN34UuTiJa6lqNDcpsVpk5Gdfflk/NqyQhdgGlshgM1PCDyAAMZYRjv7kJjNEPVSwsGAEWMUc+UWMBzXaqiiSXjalsqyq7/8crYAUOlQnKwu6yBm8+nQNCmHPlbKx94sHMTlpX2YR0ceb/fFrLOh6KfHzsnCaBZ/7msTeJJQob2JMmMAp8YRJw3jtIujxCAPyZgkT5ljthU="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -29,6 +24,14 @@ environment:
     - TARGET_ARCH: x64
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -59,7 +62,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -67,6 +69,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc
@@ -43,7 +57,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 2 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -52,6 +66,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 
@@ -22,13 +22,13 @@ requirements:
     - setuptools
     - six
     - cffi >=1.0.0
-    - enum34
+    - enum34  # [py27]
 
   run:
     - python
     - six
     - cffi >=1.0.0
-    - enum34
+    - enum34  # [py27]
 
 test:
   imports:


### PR DESCRIPTION
The package isn't currently available for python 3.6, which is causing problems for https://github.com/conda-forge/staged-recipes/pull/3373. Re-render and bump the version number so it'll get built.